### PR TITLE
Fix duplicate txt record

### DIFF
--- a/.env.local.sample
+++ b/.env.local.sample
@@ -1,6 +1,3 @@
-# Digital Ocean personal access token
-DO_TOKEN="abcd1234"
-
 # CloudFlare API Token
 CF_TOKEN="abcd1234"
 CF_DOMAIN_ID="abcd1234"

--- a/.env.local.sample
+++ b/.env.local.sample
@@ -2,9 +2,6 @@
 CF_TOKEN="abcd1234"
 CF_DOMAIN_ID="abcd1234"
 
-# DNS Provider (digitalocean, cloudflare), use cloudflare for DNSSEC
-PROVIDER="cloudflare"
-
 # Must be the root domain, not a subdomain, e.g. "example.com" and not "subdomain.example.com"
 DOMAIN="12cash.dev"
 

--- a/README.md
+++ b/README.md
@@ -54,12 +54,7 @@ You can use this tool with Cloudflare or Digital OCean DNS. However, if you want
 
 - Setup your domain with DNSSEC - [Docs](https://developers.cloudflare.com/dns/dnssec/)
 - Create an API token in Cloudflare, giving it access to your domain name
-- In the .env file, set `PROVIDER="cloudflare"` and add your Cloudflare API token and domain ID (which you can find by clicking on your domain name in Cloudflare and scrolling down the page)
-
-### Digital Ocean
-
-- Create a personal access token on Digital Ocean and add it to .env.local
-- In the .env file, set `PROVIDER="digitalocean"` and add your Digital Ocean API token
+- In the .env file, add your Cloudflare API token and domain ID (which you can find by clicking on your domain name in Cloudflare and scrolling down the page)
 
 ### Running the Dev Server
 

--- a/src/app/record/route.ts
+++ b/src/app/record/route.ts
@@ -1,8 +1,5 @@
-import { Content } from "next/font/google";
 import { NextRequest, NextResponse } from "next/server";
 const axios = require("axios").default;
-
-
 
 export async function POST(req: NextRequest) {
   let localPart: string, bolt12: string;
@@ -27,106 +24,69 @@ export async function POST(req: NextRequest) {
 
   // Begin assembling DNS name
   const fullName = process.env.NETWORK
-      ? localPart + ".user._bitcoin-payment." + process.env.NETWORK
-      : localPart + ".user._bitcoin-payment";
+    ? localPart + ".user._bitcoin-payment." + process.env.NETWORK
+    : localPart + ".user._bitcoin-payment";
 
-  // Digital Ocean
-  if(process.env.PROVIDER !== "cloudflare") {
-    const DO_URL = `https://api.digitalocean.com/v2/domains/${process.env.DOMAIN}/records`;
-    const config = {
-      headers: { Authorization: `Bearer ${process.env.DO_TOKEN}` },
-    };
-
-    
-    const queryParams = `?type=TXT&name=${fullName}.${process.env.DOMAIN}`;
-    const query = `${DO_URL}${queryParams}`;
-
-    try {
-      const res = await axios.get(query, config);
-      console.debug("query res.data", res.data);
-      console.debug("query res.data.domain_records", res.data.domain_records);
-      if (
-        res.data.domain_records.length !== 0 &&
-        res.data.domain_records[0].name === localPart
-      ) {
-        return NextResponse.json({ message: "Name is taken." }, { status: 409 });
-      }
-    } catch (error: any) {
-      console.error("error", error);
-      return NextResponse.json(
-        {
-          message: "Failed to create Paycode.",
+  // First do a DoH lookup to see if a TXT record exists for the given name
+  try {
+    const res = await axios.get(
+      `https://cloudflare-dns.com/dns-query?name=${fullName}.${process.env.DOMAIN}&type=txt`,
+      {
+        headers: {
+          Accept: "application/dns-json",
         },
-        { status: 400 }
-      );
-    }
-
-    const data = {
-      type: "TXT",
-      name: fullName,
-      data: "bitcoin:?lno=" + bolt12,
-      priority: null,
-      port: null,
-      ttl: 1800,
-      weight: null,
-      flags: null,
-      tag: null,
-    };
-
-    try {
-      const res = await axios.post(DO_URL, data, config);
-      console.debug(res.data);
-    } catch (error: any) {
+      }
+    );
+    // Answer is an array if there are records, undefined otherwise
+    if (res.data.Answer)
       return NextResponse.json(
-        { message: "Failed to create Paycode." },
-        { status: 400 }
+        { message: "Name is already taken." },
+        { status: 409 }
       );
-    }
-
+  } catch (e: any) {
     return NextResponse.json(
-      { message: "Bolt12 Address Created" },
-      { status: 201 }
+      { message: "Failed to lookup paycode." },
+      { status: 400 }
     );
   }
-  // Cloudflare
-  else {
-    const CF_URL = `https://api.cloudflare.com/client/v4/zones/${process.env.CF_DOMAIN_ID}/dns_records/`;
-    
-    const config = {
-      method: "POST",
-      headers: {
-        Content_Type: "application/json",
-        Authorization: `Bearer ${process.env.CF_TOKEN}`
-      }
-    };
 
-    const data = {
-      content: "bitcoin:?lno=" + bolt12,
-      name: `${fullName}.${process.env.DOMAIN}`,
-      proxied: false,
-      type: "TXT",
-      comment: "Twelve Cash User DNS Update",
-      ttl: 3600
-    };
+  const CF_URL = `https://api.cloudflare.com/client/v4/zones/${process.env.CF_DOMAIN_ID}/dns_records/`;
 
-    try {
-      const res = await axios.post(CF_URL, data, config);
-      console.debug(res.data);
-    } catch (error: any) {
-      let message = "Failed to create Paycode."
-      if(error.response.data.errors[0].code === 81058) {
-          message = "Name is already taken."
-      }
+  const config = {
+    method: "POST",
+    headers: {
+      Content_Type: "application/json",
+      Authorization: `Bearer ${process.env.CF_TOKEN}`,
+    },
+  };
+
+  const data = {
+    content: "bitcoin:?lno=" + bolt12,
+    name: `${fullName}.${process.env.DOMAIN}`,
+    proxied: false,
+    type: "TXT",
+    comment: "Twelve Cash User DNS Update",
+    ttl: 3600,
+  };
+
+  try {
+    const res = await axios.post(CF_URL, data, config);
+    console.debug(res.data);
+  } catch (error: any) {
+    if (error.response.data.errors[0].code === 81058) {
       return NextResponse.json(
-        
-        { message: message },
-        { status: 400 }
+        { message: "Name is already taken." },
+        { status: 409 }
       );
     }
-
     return NextResponse.json(
-      { message: "Bolt12 Address Created" },
-      { status: 201 }
+      { message: "Failed to create Paycode." },
+      { status: 400 }
     );
   }
+
+  return NextResponse.json(
+    { message: "Bolt12 Address Created" },
+    { status: 201 }
+  );
 }


### PR DESCRIPTION
- Removed DO code
- Added a step to check for an existing record via CloudFlare DoH before attempting to create the record
- Returns a 409 in the creation attempt instead of 400 if a duplicate is found at that point

[fix-duplicates-v1](https://github.com/ATLBitLab/twelvecash/issues/6)

```
#initial creation
curl -X POST http://localhost:3000/record -H "Content-Type: application/json" -d  '{"localPart": "cw-test-70", "bolt12": "lno...."}'
{"message":"Bolt12 Address Created"}

# same name and values
curl -X POST http://localhost:3000/record -H "Content-Type: application/json" -d  '{"localPart": "cw-test-70", "bolt12": "lno...."}'
{"message":"Name is already taken."}

# same name different values
curl -X POST http://localhost:3000/record -H "Content-Type: application/json" -d  '{"localPart": "cw-test-70", "bolt12": "lno....zzz"}'
{"message":"Name is already taken."}
```