### PR TITLE
add the ability to use both paid and free endpoints in the new ui

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -27,7 +27,7 @@ export default function RootLayout({
               <Header />
               <div className="min-h-full p-4">{children}</div>
               <footer className="border-t border-t-purple-800 pt-2 mt-4 text-purple-800">
-                <ul className="flex flex-col gap-2 md:flex-row md:gap-4 md: p-4">
+                <ul className="flex flex-col gap-2 md:flex-row md:gap-4 md: p-4 items-center justify-center">
                   <li>
                     <a href="https://github.com/ATLBitLab/twelvecash">
                       Developer Docs


### PR DESCRIPTION
A quick hack to get this to work the validator to work for both of these api endpoints.

Only problem is it resets the username and triggers the validator when switching back to the paid view. This sets the form description to an error since the username is set back to an empty string.
