### PR TITLE
Fix and test createBip21FromParams function

### DIFF
--- a/src/lib/util/index.test.ts
+++ b/src/lib/util/index.test.ts
@@ -1,3 +1,6 @@
+import { PayCodeParamType } from "@prisma/client";
+import { createBip21FromParams, Param } from ".";
+
 const { lnAddrToLNURL, createBip21 } = require("./index");
 
 test("try using different lightning address inputs", () => {
@@ -128,5 +131,93 @@ test.each(testCases)(
   }
 );
 
-// TODO: test this
-// createBip21FromParams
+const onChainParam: Param = {
+  prefix: null,
+  value: onChain,
+  type: PayCodeParamType.ONCHAIN,
+};
+const labelParam: Param = {
+  prefix: null,
+  value: label,
+  type: PayCodeParamType.LABEL,
+};
+const spParam: Param = {
+  prefix: null,
+  value: sp,
+  type: PayCodeParamType.SP,
+};
+const lnoParam: Param = {
+  prefix: null,
+  value: lno,
+  type: PayCodeParamType.LNO,
+};
+const lnurlParam: Param = {
+  prefix: null,
+  value: lnurl,
+  type: PayCodeParamType.LNURL,
+};
+const customParam1: Param = {
+  prefix: "apple",
+  value: "banana",
+  type: PayCodeParamType.CUSTOM,
+};
+const customParam2: Param = {
+  prefix: "coconut",
+  value: "tree",
+  type: PayCodeParamType.CUSTOM,
+};
+const createBip21FromParamsTestCases = [
+  { input: [], expected: "No parameters", shouldThrow: true },
+  {
+    input: [spParam],
+    expected: `bitcoin:?sp=${spParam.value}`,
+    shouldThrow: false,
+  },
+  {
+    // no label if no onChain address
+    input: [spParam, labelParam],
+    expected: `bitcoin:?sp=${spParam.value}`,
+    shouldThrow: false,
+  },
+  {
+    input: [lnurlParam, lnoParam],
+    expected: `bitcoin:?lnurl=${lnurlParam.value}&lno=${lnoParam.value}`,
+    shouldThrow: false,
+  },
+  {
+    input: [customParam1],
+    expected: `bitcoin:?${customParam1.prefix}=${customParam1.value}`,
+    shouldThrow: false,
+  },
+  {
+    input: [onChainParam],
+    expected: `bitcoin:${onChainParam.value}`,
+    shouldThrow: false,
+  },
+  {
+    input: [onChainParam, labelParam],
+    expected: `bitcoin:${onChainParam.value}?label=${labelParam.value}`,
+    shouldThrow: false,
+  },
+  {
+    input: [onChainParam, spParam],
+    expected: `bitcoin:${onChainParam.value}?sp=${spParam.value}`,
+    shouldThrow: false,
+  },
+  {
+    input: [onChainParam, customParam2, customParam1],
+    expected: `bitcoin:${onChainParam.value}?${customParam2.prefix}=${customParam2.value}&${customParam1.prefix}=${customParam1.value}`,
+    shouldThrow: false,
+  },
+];
+
+test.each(createBip21FromParamsTestCases)(
+  "createBip21FromParams should return $expected",
+  ({ input, expected, shouldThrow }) => {
+    if (shouldThrow) {
+      expect(() => createBip21FromParams(input)).toThrow(expected);
+    } else {
+      expect(createBip21FromParams(input)).toBe(expected);
+    }
+  }
+);

--- a/src/lib/util/index.test.ts
+++ b/src/lib/util/index.test.ts
@@ -15,10 +15,11 @@ const lno =
   "lno1qsgqmqvgm96frzdg8m0gc6nzeqffvzsqzrxqy32afmr3jn9ggkwg3egfwch2hy0l6jut6vfd8vpsc3h89l6u3dm4q2d6nuamav3w27xvdmv3lpgklhg7l5teypqz9l53hj7zvuaenh34xqsz2sa967yzqkylfu9xtcd5ymcmfp32h083e805y7jfd236w9afhavqqvl8uyma7x77yun4ehe9pnhu2gekjguexmxpqjcr2j822xr7q34p078gzslf9wpwz5y57alxu99s0z2ql0kfqvwhzycqq45ehh58xnfpuek80hw6spvwrvttjrrq9pphh0dpydh06qqspp5uq4gpyt6n9mwexde44qv7lstzzq60nr40ff38u27un6y53aypmx0p4qruk2tf9mjwqlhxak4znvna5y";
 const sp =
   "sp1qqweplq6ylpfrzuq6hfznzmv28djsraupudz0s0dclyt8erh70pgwxqkz2ydatksrdzf770umsntsmcjp4kcz7jqu03jeszh0gdmpjzmrf5u4zh0c";
+const lnurl =
+  "lnurl1dp68gurn8ghj7um5wf5kkefwd4jj7tnhv4kxctttdehhwm30d3h82unvwqhkx6rpvsclqksp";
 const custom1 = {
-  prefix: "lnurl",
-  value:
-    "lnurl1dp68gurn8ghj7um5wf5kkefwd4jj7tnhv4kxctttdehhwm30d3h82unvwqhkx6rpvsclqksp",
+  prefix: "someCustom",
+  value: "someCustomValue",
 };
 const custom2 = {
   prefix: "chad",
@@ -88,23 +89,41 @@ const testCases = [
       lno: "lno123...xyz",
       sp: "sp123...xyz",
       onChain: "bc1p...xyz",
+      lnurl: "lnurl...xyz",
       custom: [
-        { prefix: "lnurl", value: "lnur123...xyz" },
+        { prefix: "food", value: "yum" },
         { prefix: "veggie", value: "carrot" },
       ],
     },
-    expected: `bitcoin:bc1p...xyz?lno=lno123...xyz&sp=sp123...xyz&lnurl=lnur123...xyz&veggie=carrot`,
+    expected: `bitcoin:bc1p...xyz?lno=lno123...xyz&sp=sp123...xyz&lnurl=lnurl...xyz&food=yum&veggie=carrot`,
     shouldThrow: false,
   },
 ];
-// TODO: Fix
 test.each(testCases)(
   "createBip21($input) should return $expected",
   ({ input, expected, shouldThrow }) => {
     if (shouldThrow) {
-      expect(() => createBip21(input)).toThrow(expected);
+      expect(() =>
+        createBip21(
+          input.onChain,
+          input.label,
+          input.lno,
+          input.sp,
+          input.lnurl,
+          input.custom
+        )
+      ).toThrow(expected);
     } else {
-      expect(createBip21(input)).toBe(expected);
+      expect(
+        createBip21(
+          input.onChain,
+          input.label,
+          input.lno,
+          input.sp,
+          input.lnurl,
+          input.custom
+        )
+      ).toBe(expected);
     }
   }
 );

--- a/src/lib/util/index.ts
+++ b/src/lib/util/index.ts
@@ -96,18 +96,17 @@ export const createPayCodeParams = (
   return create;
 };
 
-type Param = {
+export type Param = {
   prefix: string | null;
   value: string;
   type: PayCodeParamType;
 };
 
 export const createBip21FromParams = (params: Param[]) => {
+  if (params.length === 0) throw new Error("No parameters");
   const base = "bitcoin:";
   const url = new URL(base);
   for (let param of params) {
-    if (param.type === PayCodeParamType.LABEL)
-      url.searchParams.append("label", param.value);
     if (param.type === PayCodeParamType.LNO)
       url.searchParams.append("lno", param.value);
     if (param.type === PayCodeParamType.SP)
@@ -122,15 +121,15 @@ export const createBip21FromParams = (params: Param[]) => {
       const onChainUrl = new URL(`${base}${param.value}`);
       for (let innerParam of params) {
         if (innerParam.type === PayCodeParamType.LABEL)
-          url.searchParams.append("label", innerParam.value);
+          onChainUrl.searchParams.append("label", innerParam.value);
         if (innerParam.type === PayCodeParamType.LNO)
-          url.searchParams.append("lno", innerParam.value);
+          onChainUrl.searchParams.append("lno", innerParam.value);
         if (innerParam.type === PayCodeParamType.SP)
-          url.searchParams.append("sp", innerParam.value);
+          onChainUrl.searchParams.append("sp", innerParam.value);
         if (innerParam.type === PayCodeParamType.LNURL)
-          url.searchParams.append("lnurl", innerParam.value);
+          onChainUrl.searchParams.append("lnurl", innerParam.value);
         if (innerParam.type === PayCodeParamType.CUSTOM)
-          url.searchParams.append(innerParam.prefix!, param.value);
+          onChainUrl.searchParams.append(innerParam.prefix!, innerParam.value);
       }
       return onChainUrl.toString();
     }


### PR DESCRIPTION
Added tests for `createBip21FromParams` and fixed a bug. Also fixed the `createBip21` test that I broke with recent changes.

When the user requests a new paycode for sats, it's added to the database and set to pending status.
After the user pays the invoice, we recreate the actual bip353 string from the Params stored in the database from the initial request.

From these tests I found a bug where only an on chain address was added to the bip353 txt if they had an on chain address plus any other additional parameters.

Examples of this working now
```
dig txt testa3.user._bitcoin-payment.regtest.12cash.dev
testa3.user._bitcoin-payment.regtest.12cash.dev. 3600 IN TXT "bitcoin:bc123?label=yeet&lno=lno123&sp=sp123&lnurl=lnurl123"

dig txt testa4.user._bitcoin-payment.regtest.12cash.dev
testa4.user._bitcoin-payment.regtest.12cash.dev. 3600 IN TXT "bitcoin:?lno=lno123&sp=sp123&lnurl=lnurl123"
```